### PR TITLE
MOBILE-3213 core: Revert keyboard plugin to 2.1.3

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -186,7 +186,7 @@
     </gap:plugin>
     <gap:plugin name="cordova-plugin-globalization" source="npm" spec="1.11.0" />
     <gap:plugin name="cordova-plugin-inappbrowser" source="npm" spec="3.1.0" />
-    <gap:plugin name="cordova-plugin-ionic-keyboard" source="npm" spec="2.2.0" />
+    <gap:plugin name="cordova-plugin-ionic-keyboard" source="npm" spec="2.1.3" />
     <gap:plugin name="cordova-plugin-local-notification" source="git" version="https://github.com/moodlemobile/cordova-plugin-local-notification.git#moodle" />
     <gap:plugin name="cordova-plugin-media-capture" source="npm" spec="3.0.3" />
     <gap:plugin name="cordova-plugin-network-information" source="npm" spec="2.0.2" />


### PR DESCRIPTION
The 2.2.0 version causes the input text to be behind the keyboard when sending messages.